### PR TITLE
Teku support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@
 
 | Client     | Supported | Protocols | Supported features                 |
 |------------|-----------|-----------|------------------------------------|
-| Prysm      | ✅         | GRPC      | Version, head, sync stats, metrics |
+| Prysm      | ✅         | GRPC      | Version, head, sync stats, memory |
 | Lighthouse | ✅         | HTTP      | Version, head                      |
-| Teku       | ✅         | HTTP      | Version, head                     |
+| Teku       | ✅         | HTTP      | Version, head, memory             |
 | Lodestar   |           |           |                                    |
 | Nimbus     |           |           |                                    |
 | Trinity    |           |           |                                    |
@@ -103,4 +103,13 @@ Example for Lighthouse:
                    --beacon.type="lighthouse" --beacon.addr="localhost:5052"
 ```
 
+#### Memory usage metrics
+
 If you want to see your beacon node client's memory usage as well, make sure you have metrics enabled in Prysm and add this cli argument, pointing at the right host `--beacon.metrics-addr="http://localhost:8080/metrics"`.
+
+Default metrics endpoints of supported clients:
+- Lighthouse: `127.0.0.1:5052/metrics` (under regular http API address and port), currently not supporting the memory metric.
+- Teku: `127.0.0.1:8008/metrics` (using `--metrics-enabled=true`)
+- Prysm: `127.0.0.1:8080/metrics`, monitoring enabled by default.
+
+The `process_resident_memory_bytes` gauge is extracted from the Prometheus metrics endpoint.

--- a/README.md
+++ b/README.md
@@ -103,13 +103,21 @@ Example for Lighthouse:
                    --beacon.type="lighthouse" --beacon.addr="localhost:5052"
 ```
 
+Example for Teku:
+```shell script
+./eth2stats-client run \
+                   --eth2stats.node-name="YourNode" \
+                   --eth2stats.addr="grpc.summer.eth2stats.io:443" --eth2stats.tls=true \
+                   --beacon.type="teku" --beacon.addr="localhost:5051"
+```
+
 #### Memory usage metrics
 
-If you want to see your beacon node client's memory usage as well, make sure you have metrics enabled in Prysm and add this cli argument, pointing at the right host `--beacon.metrics-addr="http://localhost:8080/metrics"`.
+If you want to see your beacon node client's memory usage as well, make sure you have metrics enabled and add this cli argument, pointing at the right host `--beacon.metrics-addr="http://127.0.0.1:8080/metrics"`.
 
 Default metrics endpoints of supported clients:
 - Lighthouse: `127.0.0.1:5052/metrics` (under regular http API address and port), currently not supporting the memory metric.
-- Teku: `127.0.0.1:8008/metrics` (using `--metrics-enabled=true`)
+- Teku: `127.0.0.1:8008/metrics` (using `--metrics-enabled=true` in Teku options)
 - Prysm: `127.0.0.1:8080/metrics`, monitoring enabled by default.
 
 The `process_resident_memory_bytes` gauge is extracted from the Prometheus metrics endpoint.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@
 > More to come soon.
 
 ## Supported clients and protocols:
-- [ ] Prysm
-  - [x] GRPC
-  - [ ] HTTP
-- [ ] Lighthouse
-  - [X] HTTP
-  - [ ] Websockets
-- [ ] Artemis
-- [ ] ...
+
+| Client     | Supported | Protocols | Supported features                 |
+|------------|-----------|-----------|------------------------------------|
+| Prysm      | ✅         | GRPC      | Version, head, sync stats, metrics |
+| Lighthouse | ✅         | HTTP      | Version, head                      |
+| Teku       | ✅         | HTTP      | Version, head                     |
+| Lodestar   |           |           |                                    |
+| Nimbus     |           |           |                                    |
+| Trinity    |           |           |                                    |
+
   
 ## Current live deployments:
 

--- a/beacon/lighthouse/lighthouse.go
+++ b/beacon/lighthouse/lighthouse.go
@@ -2,6 +2,7 @@ package lighthouse
 
 import (
 	"fmt"
+	"github.com/alethio/eth2stats-client/beacon/polling"
 	"net/http"
 
 	"github.com/dghubble/sling"
@@ -78,7 +79,7 @@ func (s *LighthouseHTTPClient) GetChainHead() (*types.ChainHead, error) {
 }
 
 func (c *LighthouseHTTPClient) SubscribeChainHeads() (beacon.ChainHeadSubscription, error) {
-	sub := NewChainHeadSubscription(c)
+	sub := polling.NewChainHeadClientPoller(c)
 	go sub.Start()
 
 	return sub, nil

--- a/beacon/teku/teku.go
+++ b/beacon/teku/teku.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/alethio/eth2stats-client/beacon/polling"
 	"net/http"
+	"strconv"
 
 	"github.com/dghubble/sling"
 	"github.com/sirupsen/logrus"
@@ -32,12 +33,16 @@ func (s *TekuHTTPClient) GetVersion() (string, error) {
 func (s *TekuHTTPClient) GetGenesisTime() (int64, error) {
 	// node/genesis_time instead of beacon/genesis_time like lighthouse.
 	path := fmt.Sprintf("node/genesis_time")
-	genesis := new(int64)
+	genesis := new(string)
 	_, err := s.api.New().Get(path).ReceiveSuccess(genesis)
 	if err != nil {
 		return 0, err
 	}
-	return *genesis, nil
+	genesisTime, err := strconv.ParseInt(*genesis, 0, 64)
+	if err != nil {
+		return 0, err
+	}
+	return genesisTime, nil
 }
 
 func (s *TekuHTTPClient) GetPeerCount() (int64, error) {

--- a/beacon/teku/teku.go
+++ b/beacon/teku/teku.go
@@ -61,7 +61,7 @@ func (s *TekuHTTPClient) GetAttestationsInPoolCount() (int64, error) {
 }
 
 func (s *TekuHTTPClient) GetSyncStatus() (bool, error) {
-	path := fmt.Sprintf("beacon/head")
+	path := fmt.Sprintf("node/syncing")
 	type syncStatus struct {
 		Syncing bool `json:"syncing"`
 		// Note: ignore "sync_status" field
@@ -75,7 +75,7 @@ func (s *TekuHTTPClient) GetSyncStatus() (bool, error) {
 }
 
 func (s *TekuHTTPClient) GetChainHead() (*types.ChainHead, error) {
-	path := fmt.Sprintf("beacon/head")
+	path := fmt.Sprintf("beacon/chainhead")
 	type chainHead struct {
 		// Slight difference from lighthouse, to be standardized in new API proposal.
 		HeadSlot           uint64 `json:"head_slot"`

--- a/beacon/teku/teku.go
+++ b/beacon/teku/teku.go
@@ -1,0 +1,105 @@
+package teku
+
+import (
+	"fmt"
+	"github.com/alethio/eth2stats-client/beacon/polling"
+	"net/http"
+
+	"github.com/dghubble/sling"
+	"github.com/sirupsen/logrus"
+
+	"github.com/alethio/eth2stats-client/beacon"
+	"github.com/alethio/eth2stats-client/types"
+)
+
+var log = logrus.WithField("module", "teku")
+
+type TekuHTTPClient struct {
+	api    *sling.Sling
+	client *http.Client
+}
+
+func (s *TekuHTTPClient) GetVersion() (string, error) {
+	path := fmt.Sprintf("node/version")
+	version := new(string)
+	_, err := s.api.New().Get(path).ReceiveSuccess(version)
+	if err != nil {
+		return "", err
+	}
+	return *version, nil
+}
+
+func (s *TekuHTTPClient) GetGenesisTime() (int64, error) {
+	// node/genesis_time instead of beacon/genesis_time like lighthouse.
+	path := fmt.Sprintf("node/genesis_time")
+	genesis := new(int64)
+	_, err := s.api.New().Get(path).ReceiveSuccess(genesis)
+	if err != nil {
+		return 0, err
+	}
+	return *genesis, nil
+}
+
+func (s *TekuHTTPClient) GetPeerCount() (int64, error) {
+	// Teku also has a `network/peers` endpoint like lighthouse, but this is more efficient.
+	path := fmt.Sprintf("network/peer_count")
+	peerCount := new(int64)
+	_, err := s.api.New().Get(path).ReceiveSuccess(peerCount)
+	if err != nil {
+		return 0, err
+	}
+	return *peerCount, nil
+}
+
+func (s *TekuHTTPClient) GetAttestationsInPoolCount() (int64, error) {
+	return 0, beacon.NotImplemented
+}
+
+func (s *TekuHTTPClient) GetSyncStatus() (bool, error) {
+	path := fmt.Sprintf("beacon/head")
+	type syncStatus struct {
+		Syncing bool `json:"syncing"`
+		// Note: ignore "sync_status" field
+	}
+	status := new(syncStatus)
+	_, err := s.api.New().Get(path).ReceiveSuccess(status)
+	if err != nil {
+		return false, err
+	}
+	return status.Syncing, nil
+}
+
+func (s *TekuHTTPClient) GetChainHead() (*types.ChainHead, error) {
+	path := fmt.Sprintf("beacon/head")
+	type chainHead struct {
+		// Slight difference from lighthouse, to be standardized in new API proposal.
+		HeadSlot           uint64 `json:"head_slot"`
+		HeadBlockRoot      string `json:"head_block_root"`
+		FinalizedSlot      uint64 `json:"finalized_slot"`
+		FinalizedBlockRoot string `json:"finalized_block_root"`
+		JustifiedSlot      uint64 `json:"justified_slot"`
+		JustifiedBlockRoot string `json:"justified_block_root"`
+		// Note: some fields, like epochs and previous justified epoch, are ignored.
+	}
+	head := new(chainHead)
+	_, err := s.api.New().Get(path).ReceiveSuccess(head)
+	if err != nil {
+		return nil, err
+	}
+	typesChainHead := types.ChainHead(*head)
+	return &typesChainHead, nil
+}
+
+func (c *TekuHTTPClient) SubscribeChainHeads() (beacon.ChainHeadSubscription, error) {
+	sub := polling.NewChainHeadClientPoller(c)
+	go sub.Start()
+
+	return sub, nil
+}
+
+func New(httpClient *http.Client, baseURL string) *TekuHTTPClient {
+	return &TekuHTTPClient{
+		api:    sling.New().Client(httpClient).Base(baseURL),
+		client: httpClient,
+	}
+}

--- a/beacon/teku/teku.go
+++ b/beacon/teku/teku.go
@@ -78,11 +78,11 @@ func (s *TekuHTTPClient) GetChainHead() (*types.ChainHead, error) {
 	path := fmt.Sprintf("beacon/chainhead")
 	type chainHead struct {
 		// Slight difference from lighthouse, to be standardized in new API proposal.
-		HeadSlot           uint64 `json:"head_slot"`
+		HeadSlot           string `json:"head_slot"`
 		HeadBlockRoot      string `json:"head_block_root"`
-		FinalizedSlot      uint64 `json:"finalized_slot"`
+		FinalizedSlot      string `json:"finalized_slot"`
 		FinalizedBlockRoot string `json:"finalized_block_root"`
-		JustifiedSlot      uint64 `json:"justified_slot"`
+		JustifiedSlot      string `json:"justified_slot"`
 		JustifiedBlockRoot string `json:"justified_block_root"`
 		// Note: some fields, like epochs and previous justified epoch, are ignored.
 	}
@@ -91,7 +91,26 @@ func (s *TekuHTTPClient) GetChainHead() (*types.ChainHead, error) {
 	if err != nil {
 		return nil, err
 	}
-	typesChainHead := types.ChainHead(*head)
+	headSlot, err := strconv.ParseUint(head.HeadSlot, 0, 64)
+	if err != nil {
+		return nil, err
+	}
+	finalizedSlot, err := strconv.ParseUint(head.FinalizedSlot, 0, 64)
+	if err != nil {
+		return nil, err
+	}
+	justifiedSlot, err := strconv.ParseUint(head.JustifiedSlot, 0, 64)
+	if err != nil {
+		return nil, err
+	}
+	typesChainHead := types.ChainHead{
+		HeadSlot:           headSlot,
+		HeadBlockRoot:      head.HeadBlockRoot,
+		FinalizedSlot:      finalizedSlot,
+		FinalizedBlockRoot: head.FinalizedBlockRoot,
+		JustifiedSlot:      justifiedSlot,
+		JustifiedBlockRoot: head.JustifiedBlockRoot,
+	}
 	return &typesChainHead, nil
 }
 

--- a/core/beacon.go
+++ b/core/beacon.go
@@ -13,29 +13,35 @@ import (
 )
 
 func initBeaconClient(nodeType, nodeAddr string) beacon.Client {
+	// check GRPC clients
 	switch nodeType {
 	case "prysm":
 		return prysm.New(prysm.Config{GRPCAddr: nodeAddr})
-	case "lighthouse", "teku":
-		if !IsURL(nodeAddr) {
-			log.Fatalf("invalid node URL: %s", nodeAddr)
-		}
-		var netTransport = &http.Transport{
-			Dial: (&net.Dialer{
-				Timeout: 15 * time.Second,
-			}).Dial,
-			TLSHandshakeTimeout: 15 * time.Second,
-		}
-		var httpClient = &http.Client{
-			Timeout:   time.Second * 10,
-			Transport: netTransport,
-		}
-		switch nodeType {
-		case "lighthouse":
-			return lighthouse.New(httpClient, nodeAddr)
-		case "teku":
-			return teku.New(httpClient, nodeAddr)
-		}
+	default:
+		break
+	}
+
+	// If not GRPC, then default to HTTP
+	// FIXME: For clients with multiple supported types, enable the user to select the type.
+	if !IsURL(nodeAddr) {
+		log.Fatalf("invalid node URL: %s", nodeAddr)
+	}
+	var netTransport = &http.Transport{
+		Dial: (&net.Dialer{
+			Timeout: 15 * time.Second,
+		}).Dial,
+		TLSHandshakeTimeout: 15 * time.Second,
+	}
+	var httpClient = &http.Client{
+		Timeout:   time.Second * 10,
+		Transport: netTransport,
+	}
+
+	switch nodeType {
+	case "lighthouse":
+		return lighthouse.New(httpClient, nodeAddr)
+	case "teku":
+		return teku.New(httpClient, nodeAddr)
 	default:
 		log.Fatalf("node type not recognized: %s", nodeType)
 		return nil

--- a/core/beacon.go
+++ b/core/beacon.go
@@ -1,13 +1,14 @@
 package core
 
 import (
+	"github.com/alethio/eth2stats-client/beacon/lighthouse"
+	"github.com/alethio/eth2stats-client/beacon/teku"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/alethio/eth2stats-client/beacon"
-	"github.com/alethio/eth2stats-client/beacon/lighthouse"
 	"github.com/alethio/eth2stats-client/beacon/prysm"
 )
 
@@ -15,7 +16,7 @@ func initBeaconClient(nodeType, nodeAddr string) beacon.Client {
 	switch nodeType {
 	case "prysm":
 		return prysm.New(prysm.Config{GRPCAddr: nodeAddr})
-	case "lighthouse":
+	case "lighthouse", "teku":
 		if !IsURL(nodeAddr) {
 			log.Fatalf("invalid node URL: %s", nodeAddr)
 		}
@@ -29,7 +30,12 @@ func initBeaconClient(nodeType, nodeAddr string) beacon.Client {
 			Timeout:   time.Second * 10,
 			Transport: netTransport,
 		}
-		return lighthouse.New(httpClient, nodeAddr)
+		switch nodeType {
+		case "lighthouse":
+			return lighthouse.New(httpClient, nodeAddr)
+		case "teku":
+			return teku.New(httpClient, nodeAddr)
+		}
 	default:
 		log.Fatalf("node type not recognized: %s", nodeType)
 		return nil


### PR DESCRIPTION
Support the Teku client and its slightly different HTTP API.

Teku has the same memory usage gauge as prysm, so that works out of the box already.
I checked Lighthouse, but they don't have that same memory gauge in their prometheus metrics. Asked them to support it.

I'll try make some PRs for Nimbus and Lodestar as well, branching off from this PR.

Also updated the readme to include teku and metrics information.

Note: I tested the individual http endpoints on my Teku test node, but since I lack the complete Eth2stats codebase, I couldn't test this right away. I'll try to point this client to eth2stats public endpoint now, and hope I don't break things :grimacing: 