### PR TITLE
Allow to specify TLS cert for secure GRPC connection to Beacon Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,18 @@ docker run -d --name eth2stats --restart always --network="host" \
 
 You should now be able to see your node and it's stats on [eth2stats](https://eth2stats.io).
 
+### Securing your gRPC connection to the Beacon Chain
+
+If your Beacon node uses a TLS connection for its GRPC endpoint you need to provide a valid certificate to `eth2stats-client` via the `--beacon.tls-cert` flag:
+
+```shell script
+docker run -d --name eth2stats --restart always --network="host" \
+      -v ~/eth2stats/data:/data \
+      ... # omitted for brevity
+      --beacon.type="prysm" --beacon.addr="localhost:4000" --beacon.tls-cert "/data/cert.pem"
+```
+
+Have a look at Prysm's documentation to learn [how to start their Beacon Chain with enabled TLS](https://docs.prylabs.network/docs/prysm-usage/secure-grpc) and how to [generate and use self-signed certificates](https://docs.prylabs.network/docs/prysm-usage/secure-grpc#generating-self-signed-tls-certificates).
 
 ## Building from source
 ### Prerequisites

--- a/commands/run.go
+++ b/commands/run.go
@@ -35,6 +35,7 @@ var runCmd = &cobra.Command{
 					BeaconNode: core.BeaconNodeConfig{
 						Type:        viper.GetString("beacon.type"),
 						Addr:        viper.GetString("beacon.addr"),
+						TLSCert:     viper.GetString("beacon.tls-cert"),
 						MetricsAddr: viper.GetString("beacon.metrics-addr"),
 					},
 					DataFolder: viper.GetString("data.folder"),
@@ -74,6 +75,9 @@ func init() {
 
 	runCmd.Flags().String("beacon.addr", "", "Beacon node endpoint address")
 	viper.BindPFlag("beacon.addr", runCmd.Flag("beacon.addr"))
+
+	runCmd.Flags().String("beacon.tls-cert", "", "Beacon node certificate to secure gRPC connection")
+	viper.BindPFlag("beacon.tls-cert", runCmd.Flag("beacon.tls-cert"))
 
 	runCmd.Flags().String("beacon.metrics-addr", "", "The url where the beacon client exposes metrics (used for memory usage)")
 	viper.BindPFlag("beacon.metrics-addr", runCmd.Flag("beacon.metrics-addr"))

--- a/core/beacon.go
+++ b/core/beacon.go
@@ -1,23 +1,23 @@
 package core
 
 import (
-	"github.com/alethio/eth2stats-client/beacon/lighthouse"
-	"github.com/alethio/eth2stats-client/beacon/nimbus"
-	"github.com/alethio/eth2stats-client/beacon/teku"
 	"net"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/alethio/eth2stats-client/beacon"
+	"github.com/alethio/eth2stats-client/beacon/lighthouse"
+	"github.com/alethio/eth2stats-client/beacon/nimbus"
 	"github.com/alethio/eth2stats-client/beacon/prysm"
+	"github.com/alethio/eth2stats-client/beacon/teku"
 )
 
-func initBeaconClient(nodeType, nodeAddr string) beacon.Client {
+func initBeaconClient(nodeType, nodeAddr, nodeCert string) beacon.Client {
 	// check GRPC clients
 	switch nodeType {
 	case "prysm":
-		return prysm.New(prysm.Config{GRPCAddr: nodeAddr})
+		return prysm.New(prysm.Config{GRPCAddr: nodeAddr, TLSCert: nodeCert})
 	default:
 		break
 	}
@@ -26,6 +26,11 @@ func initBeaconClient(nodeType, nodeAddr string) beacon.Client {
 	// FIXME: For clients with multiple supported types, enable the user to select the type.
 	if !IsURL(nodeAddr) {
 		log.Fatalf("invalid node URL: %s", nodeAddr)
+	}
+	// Custom TLS certificates have only been tested with GRPC connections.
+	// Fail early here to avoid mistakes. This can be implemented later if needed.
+	if nodeCert != "" {
+		log.Fatal("custom TLS certificates are currently only supported for GRPC connections")
 	}
 	var netTransport = &http.Transport{
 		Dial: (&net.Dialer{

--- a/core/core.go
+++ b/core/core.go
@@ -26,6 +26,7 @@ type Eth2statsConfig struct {
 type BeaconNodeConfig struct {
 	Type        string
 	Addr        string
+	TLSCert     string
 	MetricsAddr string
 }
 
@@ -49,7 +50,7 @@ type Core struct {
 func New(config Config) *Core {
 	c := Core{
 		config:       config,
-		beaconClient: initBeaconClient(config.BeaconNode.Type, config.BeaconNode.Addr),
+		beaconClient: initBeaconClient(config.BeaconNode.Type, config.BeaconNode.Addr, config.BeaconNode.TLSCert),
 	}
 
 	c.initEth2statsClient()


### PR DESCRIPTION
This allows to specify a custom TLS certificate for the GRPC connection to the beacon chain (only supported by prysm at the moment).

Implements https://github.com/Alethio/eth2stats-client/issues/27

It's backwards compatible. If no `--beacon.tls-cert` is provided it uses the current behaviour. It prints a warning about the insecure connection, though.

I didn't test a custom TLS cert for HTTPS connections, e.g. to lighthouse, and I don't know if it makes sense. Therefore, this case is guarded so no one accidentally configures it.

The implementation is highly inspired by prysm's source code, e.g. [here](https://github.com/prysmaticlabs/prysm/blob/c1a8b41347ac4a93bb879e0e8307987dc32215ab/slasher/beaconclient/service.go#L147-L158).