### PR TITLE
Lodestar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,20 @@
 
 > This is an intial POC release of the eth2stats network monitoring suite
 > 
-> Currently it supports Prysm and Lighthouse.
-> More to come soon.
+> It supports Prysm, Lighthouse, Teku, Nimbus and Lodestar.
+> However, none of the APIs are standardized, 
+> and once the standard lands the client will be refactored to support just that.
 
 ## Supported clients and protocols:
 
-| Client     | Supported | Protocols | Supported features                 |
-|------------|-----------|-----------|------------------------------------|
-| Prysm      | ✅         | GRPC      | Version, head, sync stats, memory |
-| Lighthouse | ✅         | HTTP      | Version, head                      |
-| Teku       | ✅         | HTTP      | Version, head, memory             |
-| Lodestar   |           |           |                                    |
-| Nimbus     |           |           |                                    |
-| Trinity    |           |           |                                    |
+| Client     | Supported | Protocols | Supported features                                   |
+|------------|-----------|-----------|------------------------------------------------------|
+| Prysm      | ✅        | GRPC      | Version, head, sync stats, memory, attestation count |
+| Lighthouse | ✅        | HTTP      | Version, head, sync stats, memory                    |
+| Teku       | ✅        | HTTP      | Version, head, sync stats, memory                    |
+| Lodestar   | ✅        | HTTP      | Version, head, sync stats, memory                    |
+| Nimbus     | ✅        | HTTP      | Version, head, sync stats, memory                    |
+| Trinity    |           |           |                                                      |
 
   
 ## Current live deployments:
@@ -99,29 +100,20 @@ make build
 
 **Run**
 
-Example for Prysm:
-```shell script
-./eth2stats-client run \
-                   --eth2stats.node-name="YourNode" \
-                   --eth2stats.addr="grpc.sapphire.eth2stats.io:443" --eth2stats.tls=true \
-                   --beacon.type="prysm" --beacon.addr="localhost:4000"
-```
-
 Example for Lighthouse:
 ```shell script
 ./eth2stats-client run \
                    --eth2stats.node-name="YourNode" \
                    --eth2stats.addr="grpc.summer.eth2stats.io:443" --eth2stats.tls=true \
-                   --beacon.type="lighthouse" --beacon.addr="localhost:5052"
+                   --beacon.type="lighthouse" --beacon.addr="http://localhost:5052"
 ```
 
-Example for Teku:
-```shell script
-./eth2stats-client run \
-                   --eth2stats.node-name="YourNode" \
-                   --eth2stats.addr="grpc.schlesi.eth2stats.io:443" --eth2stats.tls=true \
-                   --beacon.type="teku" --beacon.addr="localhost:5051"
-```
+Note that since Prysm uses GRPC, the addr flag does not start with `http://`, unlike the others.
+So it would be like `--beacon.addr="localhost:4000"`.
+
+For the other clients, it is similar as lighthouse, except you replace the name.
+
+Client names are `prysm`, `lighthouse`, `teku`, `nimbus`, `lodestar`.
 
 #### Memory usage metrics
 
@@ -131,5 +123,7 @@ Default metrics endpoints of supported clients:
 - Lighthouse: `127.0.0.1:5052/metrics` (under regular http API address and port), currently not supporting the memory metric.
 - Teku: `127.0.0.1:8008/metrics` (using `--metrics-enabled=true` in Teku options)
 - Prysm: `127.0.0.1:8080/metrics`, monitoring enabled by default.
+- Nimbus: `127.0.0.1:8008/metrics` (using `--metrics --metrics-port=8008`)
+- Lodestar: `127.0.0.1:5000/metrics` (configure with `"metrics": { "enabled": true, "serverPort": 5000}` in config JSON)
 
 The `process_resident_memory_bytes` gauge is extracted from the Prometheus metrics endpoint.

--- a/beacon/lodestar/lodestar.go
+++ b/beacon/lodestar/lodestar.go
@@ -1,0 +1,141 @@
+package lodestar
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/alethio/eth2stats-client/beacon/polling"
+
+	"github.com/dghubble/sling"
+	"github.com/sirupsen/logrus"
+
+	"github.com/alethio/eth2stats-client/beacon"
+	"github.com/alethio/eth2stats-client/types"
+)
+
+var log = logrus.WithField("module", "lodestar")
+
+type LodestarHTTPClient struct {
+	api    *sling.Sling
+	client *http.Client
+}
+
+func (s *LodestarHTTPClient) GetVersion() (string, error) {
+	path := "node/version"
+	version := new(string)
+	_, err := s.api.New().Get(path).ReceiveSuccess(version)
+	if err != nil {
+		return "", err
+	}
+	return *version, nil
+}
+
+func (s *LodestarHTTPClient) GetGenesisTime() (int64, error) {
+	// node/genesis_time instead of beacon/genesis_time like lighthouse.
+	path := "node/genesis_time"
+	genesisTime := int64(0)
+	_, err := s.api.New().Get(path).ReceiveSuccess(&genesisTime)
+	if err != nil {
+		return 0, err
+	}
+	return genesisTime, nil
+}
+
+func (s *LodestarHTTPClient) GetPeerCount() (int64, error) {
+	path := "node/peers"
+	peers := new([]string)
+	_, err := s.api.New().Get(path).ReceiveSuccess(peers)
+	if err != nil {
+		return 0, err
+	}
+	return int64(len(*peers)), nil
+}
+
+func (s *LodestarHTTPClient) GetAttestationsInPoolCount() (int64, error) {
+	return 0, beacon.NotImplemented
+}
+
+func (s *LodestarHTTPClient) GetSyncStatus() (bool, error) {
+	path := fmt.Sprintf("node/syncing")
+	type lodestarSyncing struct {
+		//StartingBlock string `json:"starting_block"`
+		CurrentBlock string `json:"current_block"`
+		HighestBlock string `json:"highest_block"`
+	}
+	status := new(lodestarSyncing)
+	_, err := s.api.New().Get(path).ReceiveSuccess(status)
+	if err != nil {
+		return false, err
+	}
+	currentBlock, err := strconv.ParseUint(status.CurrentBlock, 0, 64)
+	if err != nil {
+		return false, err
+	}
+	highestBlock, err := strconv.ParseUint(status.HighestBlock, 0, 64)
+	if err != nil {
+		return false, err
+	}
+	return currentBlock < highestBlock, nil
+}
+
+func (s *LodestarHTTPClient) GetChainHead() (*types.ChainHead, error) {
+	path := fmt.Sprintf("node/head")
+	type chainHead struct {
+		HeadSlot           string `json:"head_slot"`
+		HeadBlockRoot      string `json:"head_block_root"`
+		FinalizedSlot      string `json:"finalized_slot"`
+		FinalizedBlockRoot string `json:"finalized_block_root"`
+		JustifiedSlot      string `json:"justified_slot"`
+		JustifiedBlockRoot string `json:"justified_block_root"`
+	}
+	head := new(chainHead)
+	_, err := s.api.New().Get(path).ReceiveSuccess(head)
+	if err != nil {
+		return nil, err
+	}
+	headSlot, err := strconv.ParseUint(head.HeadSlot, 0, 64)
+	if err != nil {
+		// pre genesis this is empty, return a default
+		zeroChainHead := types.ChainHead{
+			HeadSlot:           0,
+			HeadBlockRoot:      "0x0",
+			FinalizedSlot:      0,
+			FinalizedBlockRoot: "0x0",
+			JustifiedSlot:      0,
+			JustifiedBlockRoot: "0x0",
+		}
+		return &zeroChainHead, nil
+	}
+	finalizedSlot, err := strconv.ParseUint(head.FinalizedSlot, 0, 64)
+	if err != nil {
+		return nil, err
+	}
+	justifiedSlot, err := strconv.ParseUint(head.JustifiedSlot, 0, 64)
+	if err != nil {
+		return nil, err
+	}
+	typesChainHead := types.ChainHead{
+		HeadSlot:           headSlot,
+		HeadBlockRoot:      head.HeadBlockRoot,
+		FinalizedSlot:      finalizedSlot,
+		FinalizedBlockRoot: head.FinalizedBlockRoot,
+		JustifiedSlot:      justifiedSlot,
+		JustifiedBlockRoot: head.JustifiedBlockRoot,
+	}
+	return &typesChainHead, nil
+}
+
+func (c *LodestarHTTPClient) SubscribeChainHeads() (beacon.ChainHeadSubscription, error) {
+	sub := polling.NewChainHeadClientPoller(c)
+	go sub.Start()
+
+	return sub, nil
+}
+
+func New(httpClient *http.Client, baseURL string) *LodestarHTTPClient {
+	return &LodestarHTTPClient{
+		api:    sling.New().Client(httpClient).Base(baseURL),
+		client: httpClient,
+	}
+}

--- a/core/beacon.go
+++ b/core/beacon.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"github.com/alethio/eth2stats-client/beacon/lodestar"
 	"net"
 	"net/http"
 	"net/url"
@@ -50,6 +51,8 @@ func initBeaconClient(nodeType, nodeAddr, nodeCert string) beacon.Client {
 		return teku.New(httpClient, nodeAddr)
 	case "nimbus":
 		return nimbus.New(httpClient, nodeAddr)
+	case "lodestar":
+		return lodestar.New(httpClient, nodeAddr)
 	default:
 		log.Fatalf("node type not recognized: %s", nodeType)
 		return nil


### PR DESCRIPTION
Changes:
- Update readme (lodestar info, small nimbus update, generalize now that we have 5 clients)
- Implement Lodestar API client (metrics work too! No changes were necessary there, thanks to the standard memory gauge format.)

Note that lodestar is looking to adapt the new to-be-standardized API soon-ish (awesome work by @mpetrunic on both Lodestar API package and API standardization), but in the meantime I like Lodestar to be involved with Eth2stats, so I made some patches to their API to get eth2stats support working: https://github.com/ChainSafe/lodestar/pull/1125
In addition, you would need the latest lodestar SSZ updates, recent optimization PRs, which included a few minor patches too. But it works!

![image](https://user-images.githubusercontent.com/19571989/87092537-e50e4c80-c23b-11ea-9e65-b387c32eb6c3.png)


Once the standardized API lands, I'm happy to help refactor the eth2stats client again, to de-duplicate the clients, and support the new standard API. Also, as the eth2stats server was planned to be open sourced, we could add more data to the dashboard, with only a single client implementation to update.
