### PR TITLE
scratch docker amd64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 VERSION := "$(shell git describe --abbrev=0 --tags 2> /dev/null || echo 'v0.0.0')+$(shell git rev-parse --short HEAD)"
 
 build:
-	go build -ldflags "-X main.buildVersion=$(VERSION)"
+	go build -ldflags "-X main.buildVersion=$(VERSION) -extldflags "-static"" -o eth2stats-client
 
 run:
 	go run main.go


### PR DESCRIPTION
This is a draft to make the docker image smaller and more minimal by:
- using an alpine linux for the build stage
- producing a static binary
- using scratch for the running image stage

The result should be about a 20MB docker image:
![scratch](https://user-images.githubusercontent.com/19571989/89676736-71b83300-d8ec-11ea-9865-4fb1b85d7121.png)

Previously this was 100MB:
![prev](https://user-images.githubusercontent.com/19571989/89676874-b17f1a80-d8ec-11ea-9b44-ae44b654bb4c.png)

My concern now is testing the new image, and making sure it still works on ARM, Windows, Mac. Any users that like to beta test?

Beta image, if you don't want to build it yourself, here: `protolambda/eth2stats-client:scratch` [(docker hub)](https://hub.docker.com/layers/protolambda/eth2stats-client/scratch/images/sha256-05206b88a51bbb40abba04a9d5a9d0fe4a6dd8f7a622aea1f1f713701be26174?context=explore)