### PR TITLE
fix api v1 states route

### DIFF
--- a/beacon/v1/v1.go
+++ b/beacon/v1/v1.go
@@ -132,7 +132,7 @@ func (s *V1HTTPClient) GetChainHead() (*types.ChainHead, error) {
 	}
 	typesChainHead.HeadSlot = slot
 
-	finalityCheckpointsPath := "eth/v1/beacon/state/head/finality_checkpoints"
+	finalityCheckpointsPath := "eth/v1/beacon/states/head/finality_checkpoints"
 	type finalityCheckpointsType struct {
 		Data struct {
 			Finalized struct {


### PR DESCRIPTION
See https://ethereum.github.io/eth2.0-APIs/#/Beacon/getStateFinalityCheckpoints
It should be `states`, not `state`.
