### PR TITLE
attestation pool count, avoid performance problem, disable for now.

### DIFF
--- a/beacon/v1/v1.go
+++ b/beacon/v1/v1.go
@@ -81,17 +81,9 @@ func (s *V1HTTPClient) GetPeerCount() (int64, error) {
 }
 
 func (s *V1HTTPClient) GetAttestationsInPoolCount() (int64, error) {
-	path := "eth/v1/beacon/pool/attestations"
-	type attestationsResponse struct {
-		Data []struct {
-		} `json:"data,omitempty"`
-	}
-	response := new(attestationsResponse)
-	_, err := s.api.New().Get(path).ReceiveSuccess(response)
-	if err != nil {
-		return 0, err
-	}
-	return int64(len(response.Data)), nil
+	// TODO: There's an attestations pool endpoint, but it lists way too much.
+	//       So much, that querying it a lot is similar to a self-induced DoS attack.
+	return 0, beacon.NotImplemented
 }
 
 func (s *V1HTTPClient) GetSyncStatus() (bool, error) {


### PR DESCRIPTION
See https://github.com/Alethio/eth2stats-client/issues/64

And:

![image](https://user-images.githubusercontent.com/19571989/95931101-891e0b80-0dc8-11eb-94fe-dd551a1e904b.png)

The full attestations pool should not be queried every 12 seconds in JSON format.

Disabling this functionality for now, while awaiting new API endpoints, or change to use metrics instead.
